### PR TITLE
commenting out MySQL password settings

### DIFF
--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -17,10 +17,10 @@ DOCKSAL_STACK=default
 #DOCROOT=docroot
 
 # MySQL settings.
-MYSQL_ROOT_PASSWORD=root
-MYSQL_USER=user
-MYSQL_PASSWORD=user
-MYSQL_DATABASE=default
+#MYSQL_ROOT_PASSWORD=root
+#MYSQL_USER=user
+#MYSQL_PASSWORD=user
+#MYSQL_DATABASE=default
 # MySQL will be exposed on a random port. Use "fin ps" to check the port.
 # To have a static MySQL port assigned, copy the line below into the .docksal/docksal-local.env file
 # and replace the host port "0" with a unique host port number (e.g. MYSQL_PORT_MAPPING='33061:3306')


### PR DESCRIPTION
Project config overrides global config and we don't want to override configuration that may exist for security purposes. This file is here to show what can be changed.